### PR TITLE
Fix chart not working when args is empty

### DIFF
--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -20,8 +20,10 @@ spec:
           containers:
             - name: "{{ .Values.cronJobName }}"
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              {{- if gt (len .Values.args) 0 }}
               args:
 {{ toYaml .Values.args | indent 14 }}
+              {{- end }}
               imagePullPolicy: IfNotPresent
               resources:
                 requests:


### PR DESCRIPTION
- empty args should also work, but fails when
  templating

KNUTH-53444