### PR TITLE
Remove mandatory pod cpu limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # spring-service
 
+## 3.10.0
+
+- Remove pod CPU limits 
+
 ## 3.9.0
 
 **Breaking Changes**
@@ -126,6 +130,10 @@
 - New mandatory parameter: `secretsRoleArn`, necessary for secret access
 
 # cronjob
+
+## 1.6.0
+
+- Remove pod CPU limits
 
 ## 1.5.0
 

--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: cronjob
 description: A generalized cronjob that can access secrets.
-version: 1.5.0
+version: 1.6.0

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -34,7 +34,9 @@ spec:
                   cpu: {{ required "CPU guarantee must be set!" .Values.resources.cpu.guarantee }}
                   memory: {{ required "Memory requirement must be set!" .Values.resources.memory }}
                 limits:
-                  cpu: {{ required "CPU limit must be set!" .Values.resources.cpu.limit }}
+                {{- if .Values.resources.cpu.limit }}
+                  cpu: {{ .Values.resources.cpu.limit }}
+                {{- end }}
                   memory: {{ required "Memory requirement must be set!" .Values.resources.memory }}
 
               env:

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -21,7 +21,6 @@ resources:
   memory: 64Mi
   cpu:
     guarantee: 100m
-    limit: 1000m
 
 env:
   fromSecret: {}

--- a/charts/spring-service/Chart.yaml
+++ b/charts/spring-service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: spring-service
 description: A generalized deployment for Meisterplan Spring Boot services in Kubernetes.
-version: 3.9.0
+version: 3.10.0

--- a/charts/spring-service/templates/deployment.yaml
+++ b/charts/spring-service/templates/deployment.yaml
@@ -77,7 +77,9 @@ spec:
               cpu: {{ required "CPU guarantee must be set!" .Values.resources.cpu.guarantee }}
               memory: {{ required "Memory requirement must be set!" .Values.resources.memory }}
             limits:
-              cpu: {{ required "CPU limit must be set!" .Values.resources.cpu.limit }}
+              {{- if .Values.resources.cpu.limit }}
+              cpu: {{ .Values.resources.cpu.limit }}
+              {{- end }}
               memory: {{ required "Memory requirement must be set!" .Values.resources.memory }}
 
           startupProbe:

--- a/charts/spring-service/values.yaml
+++ b/charts/spring-service/values.yaml
@@ -32,7 +32,6 @@ resources:
   memory: 600Mi
   cpu:
     guarantee: 100m
-    limit: 1000m
 
 ingress:
   host: "" # Hostname under which the service is available, normally configured per deployment target

--- a/tests/cronjob/service-account-cronjob/expected/cronjob/templates/cronjob.yaml
+++ b/tests/cronjob/service-account-cronjob/expected/cronjob/templates/cronjob.yaml
@@ -33,7 +33,6 @@ spec:
                   cpu: 100m
                   memory: 64Mi
                 limits:
-                  cpu: 1
                   memory: 64Mi
 
               env:

--- a/tests/cronjob/service-account-cronjob/values.yaml
+++ b/tests/cronjob/service-account-cronjob/values.yaml
@@ -17,7 +17,6 @@ resources:
   memory: 64Mi
   cpu:
     guarantee: 100m
-    limit: 1
 
 env:
   fromSecret:

--- a/tests/cronjob/simple-cronjob/expected/cronjob/templates/cronjob.yaml
+++ b/tests/cronjob/simple-cronjob/expected/cronjob/templates/cronjob.yaml
@@ -32,7 +32,6 @@ spec:
                   cpu: 100m
                   memory: 64Mi
                 limits:
-                  cpu: 1
                   memory: 64Mi
 
               env:

--- a/tests/cronjob/simple-cronjob/values.yaml
+++ b/tests/cronjob/simple-cronjob/values.yaml
@@ -16,7 +16,6 @@ resources:
   memory: 64Mi
   cpu:
     guarantee: 100m
-    limit: 1
 
 env:
   fromSecret:

--- a/tests/spring-service/complex-service/expected/spring-service/templates/deployment.yaml
+++ b/tests/spring-service/complex-service/expected/spring-service/templates/deployment.yaml
@@ -66,7 +66,6 @@ spec:
               cpu: 500m
               memory: 1000Mi
             limits:
-              cpu: 2
               memory: 1000Mi
 
           startupProbe:

--- a/tests/spring-service/complex-service/values.yaml
+++ b/tests/spring-service/complex-service/values.yaml
@@ -14,7 +14,6 @@ resources:
   memory: 1000Mi
   cpu:
     guarantee: 500m
-    limit: 2
 
 ingress:
   host: "myservice.mycompany.tld"

--- a/tests/spring-service/simple-service/expected/spring-service/templates/deployment.yaml
+++ b/tests/spring-service/simple-service/expected/spring-service/templates/deployment.yaml
@@ -73,7 +73,6 @@ spec:
               cpu: 500m
               memory: 1000Mi
             limits:
-              cpu: 2
               memory: 1000Mi
 
           startupProbe:

--- a/tests/spring-service/simple-service/values.yaml
+++ b/tests/spring-service/simple-service/values.yaml
@@ -21,7 +21,6 @@ resources:
   memory: 1000Mi
   cpu:
     guarantee: 500m
-    limit: 2
 
 ingress:
   host: "myservice.mycompany.tld"


### PR DESCRIPTION
There is no need to set a cpu limit, but it is still possible to set one.

refs KNUTH-79040