### PR TITLE
Use ingressClassName instead of deprecated annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # spring-service
 
+## 3.13.0
+- Change deprecated ingress class annotation to ingressClassName
+
 ## 3.12.0
 
 - Add support for Spring Boot 3.

--- a/charts/spring-service/templates/post-deployment/ingress.yaml
+++ b/charts/spring-service/templates/post-deployment/ingress.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ .Values.serviceName }}
   namespace: "{{ required "Namespace must be set!" .Values.namespace }}"
   annotations:
-    kubernetes.io/ingress.class: nginx
     {{- if .Values.ingress.overwriteCustomHttpErrors }}
     nginx.ingress.kubernetes.io/custom-http-errors: {{ .Values.ingress.overwriteCustomHttpErrors }}
     {{- end }}
@@ -20,6 +19,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: {{ .Values.serviceName }}
     {{- end }}
 spec:
+  ingressClassName: nginx
   rules:
     - host: {{ required "Ingress Host must be set!" .Values.ingress.host }}
       http:

--- a/tests/spring-service/complex-service/expected/spring-service/templates/post-deployment/ingress.yaml
+++ b/tests/spring-service/complex-service/expected/spring-service/templates/post-deployment/ingress.yaml
@@ -6,12 +6,12 @@ metadata:
   name: myservice
   namespace: "team-supercool"
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/custom-http-errors: 502
     nginx.ingress.kubernetes.io/auth-type: "basic"
     nginx.ingress.kubernetes.io/auth-secret: myservice-external-secret
     nginx.ingress.kubernetes.io/auth-realm: myservice
 spec:
+  ingressClassName: nginx
   rules:
     - host: myservice.mycompany.tld
       http:

--- a/tests/spring-service/simple-service/expected/spring-service/templates/post-deployment/ingress.yaml
+++ b/tests/spring-service/simple-service/expected/spring-service/templates/post-deployment/ingress.yaml
@@ -6,12 +6,12 @@ metadata:
   name: myservice
   namespace: "team-supercool"
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/custom-http-errors: 502
     nginx.ingress.kubernetes.io/auth-type: "basic"
     nginx.ingress.kubernetes.io/auth-secret: myservice-external-secret
     nginx.ingress.kubernetes.io/auth-realm: myservice
 spec:
+  ingressClassName: nginx
   rules:
     - host: myservice.mycompany.tld
       http:


### PR DESCRIPTION
- should be relevant for rollout/deploy, unless you don't upgrade for years... (using this chart within 2023, you won't have issues as it is compatible in both ways currently)
- see https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation

KNUTH-91572