### PR TITLE
Revert "Merge pull request #49 from meisterplan/feature/KNUTH-91572"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # spring-service
 
-## 3.14.0
-- Use topologySpreadConstraints to indicate that pods should be scheduled evenly across availability zone 
-
 ## 3.13.0
 - Change deprecated ingress class annotation to ingressClassName
 

--- a/charts/spring-service/Chart.yaml
+++ b/charts/spring-service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: spring-service
 description: A generalized deployment for Meisterplan Spring Boot services in Kubernetes.
-version: 3.14.0
+version: 3.13.0

--- a/charts/spring-service/templates/deployment.yaml
+++ b/charts/spring-service/templates/deployment.yaml
@@ -56,20 +56,6 @@ spec:
                     operator: In
                     values:
                     - {{ .Values.image.tag | quote }}
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: topology.kubernetes.io/zone
-          whenUnsatisfiable: DoNotSchedule
-          labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/name
-                operator: In
-                values:
-                  - {{ .Values.serviceName | quote }}
-              - key: app.kubernetes.io/version
-                operator: In
-                values:
-                  - {{ .Values.image.tag | quote }}
       containers:
         - name: {{ .Values.serviceName }}
           image: "{{ required "repository must be set!" .Values.image.repository }}:{{ required "tag must be set!" .Values.image.tag }}"

--- a/tests/spring-service/complex-service/expected/spring-service/templates/deployment.yaml
+++ b/tests/spring-service/complex-service/expected/spring-service/templates/deployment.yaml
@@ -50,20 +50,6 @@ spec:
                     operator: In
                     values:
                     - "1.30.7"
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: topology.kubernetes.io/zone
-          whenUnsatisfiable: DoNotSchedule
-          labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/name
-                operator: In
-                values:
-                  - "myservice"
-              - key: app.kubernetes.io/version
-                operator: In
-                values:
-                  - "1.30.7"
       containers:
         - name: myservice
           image: "docker.pkg.github.com/my-company/myservice:1.30.7"

--- a/tests/spring-service/simple-service/expected/spring-service/templates/deployment.yaml
+++ b/tests/spring-service/simple-service/expected/spring-service/templates/deployment.yaml
@@ -51,20 +51,6 @@ spec:
                     operator: In
                     values:
                     - "1.30.7"
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: topology.kubernetes.io/zone
-          whenUnsatisfiable: DoNotSchedule
-          labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/name
-                operator: In
-                values:
-                  - "myservice"
-              - key: app.kubernetes.io/version
-                operator: In
-                values:
-                  - "1.30.7"
       containers:
         - name: myservice
           image: "docker.pkg.github.com/my-company/myservice:1.30.7"


### PR DESCRIPTION
This reverts commit f316a4817afd5c093ec4bfae39f7e5c166db17d9, reversing
changes made to f89a20fd2dc9b62c31e4036e934ace6dcae72532.

We think this was a misunderstanding of the docs and we don't actually need both podAntiAffinity and topologicalSpreadConstraint.

KNUTH-91572
