### PR TITLE
KNUTH-102475 Add default terminationTimeBeforeKill to Helm Chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,21 @@
 # spring-service
 
+## 3.16.0
+
+- Set default SIGKILL timeout to 5min to allow graceful shutdown of Spring server
+
 ## 3.15.0
-- Use less aggressive startup probe to give containers up to 5min starting time by default since they take a while to 
+
+- Use less aggressive startup probe to give containers up to 5min starting time by default since they take a while to
   start on newly created autoscaling nodes.
 
 ## 3.14.0
-- Use topologySpreadConstraints to enforce that pods are scheduled on at least 2 zones and hosts and otherwise evenly 
+
+- Use topologySpreadConstraints to enforce that pods are scheduled on at least 2 zones and hosts and otherwise evenly
   distributed among them, even when the cluster topology is rapidly changing (due to node autoscaling).
 
 ## 3.13.0
+
 - Change deprecated ingress class annotation to ingressClassName
 
 ## 3.12.0

--- a/charts/spring-service/Chart.yaml
+++ b/charts/spring-service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: spring-service
 description: A generalized deployment for Meisterplan Spring Boot services in Kubernetes.
-version: 3.15.0
+version: 3.16.0

--- a/charts/spring-service/values.yaml
+++ b/charts/spring-service/values.yaml
@@ -40,7 +40,7 @@ ingress:
 # Optional: Manual configuration of special timeouts for deployments.
 timeouts:
   terminationTimeBeforeSigTermSeconds: 15 # how many seconds to wait in "PreStop hook", i.e. after terminating pod but before SIGTERM to the container (e.g. for completing pending requests). If changed, the option below can also become relevant.
-#  terminationTimeBeforeKillSeconds: ? # see https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution
+  terminationTimeBeforeKillSeconds: 300 # allow Spring Server graceful shutdown - see https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution
 #  progressDeadlineSeconds: ? # see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#progress-deadline-seconds
 
 # Optional: Additional ports that can be reached by other services inside the cluster, but not by requests from the load balancer

--- a/tests/spring-service/complex-service/expected/spring-service/templates/deployment.yaml
+++ b/tests/spring-service/complex-service/expected/spring-service/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       imagePullSecrets:
         - name: docker.pkg.github.com
         - name: ghcr.io
+      terminationGracePeriodSeconds: 300
       topologySpreadConstraints:
         - topologyKey: kubernetes.io/hostname
           maxSkew: 1


### PR DESCRIPTION
Default was determined by 3 minutes Cloudfront timeout and 2 minutes buffer for terminationTimeBeforeSigTermSeconds and other shutdown delays.
