### PR TITLE
Delete prometheus rules if none are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # spring-service
 
+## 4.2.1
+
+- Add the deletion of alertingRules in the case none are set via the attribute.
+
 ## 4.2.0
 
 - Support exact paths with special characters primarily for dot (`.`).
@@ -16,15 +20,15 @@
 
 - **Breaking change:** Improve `ingress` by supporting public and private traffic routing,
   for customer-facing and internal endpoints respectively.
-  - `host` is replaced by `clusterDomain` and `public.subDomain` to simplify the deployment flow
-  - Paths that should be publicly available must be explicitly configured under `public.paths` by:
-    - allowing exact matches (`public.paths.exact`)
-    - allowing prefix matches (`public.paths.prefixes`)
-    - allowing all paths to be publicly accessible (`public.paths.allowAll: true`)
-  - Private subdomain `<service-name>.internal` is created automatically and only available from private ingress (VPN)
-  - Drop support for unused and superseded `basicAuthSecretParameterName`
+    - `host` is replaced by `clusterDomain` and `public.subDomain` to simplify the deployment flow
+    - Paths that should be publicly available must be explicitly configured under `public.paths` by:
+        - allowing exact matches (`public.paths.exact`)
+        - allowing prefix matches (`public.paths.prefixes`)
+        - allowing all paths to be publicly accessible (`public.paths.allowAll: true`)
+    - Private subdomain `<service-name>.internal` is created automatically and only available from private ingress (VPN)
+    - Drop support for unused and superseded `basicAuthSecretParameterName`
 - **Breaking change:** Rename `clusterName` to more appropriate `envName`
-- **Breaking change:** Simplify/clarify `podRoleArn` by replacing with `serviceAccount.enabled` and `awsAccountId` 
+- **Breaking change:** Simplify/clarify `podRoleArn` by replacing with `serviceAccount.enabled` and `awsAccountId`
 
 ## 3.20.0
 
@@ -132,7 +136,8 @@
 
 **Breaking Changes**
 
-> Support for `alertingRules[].summary` was dropped in favor of `alertingRules[].description`. Although backwards-compatible this is silently breaking: Defined summaries will no longer be propagated.
+> Support for `alertingRules[].summary` was dropped in favor of `alertingRules[].description`. Although backwards-compatible this is silently breaking: Defined
+> summaries will no longer be propagated.
 
 ## 3.0.0
 
@@ -146,7 +151,8 @@
 
 **Breaking changes**
 
-> :warning: **WARNING**: The first time _2.2.1 or any version after_ is deployed when _any version before 2.2.1_ is running this causes a **nonzero downtime deployment** with a short 503 service disruption due to a [bug in the ingress controller](https://github.com/kubernetes/ingress-nginx/issues/6962).
+> :warning: **WARNING**: The first time _2.2.1 or any version after_ is deployed when _any version before 2.2.1_ is running this causes a **nonzero downtime
+deployment** with a short 503 service disruption due to a [bug in the ingress controller](https://github.com/kubernetes/ingress-nginx/issues/6962).
 >
 > Please take appropriate measures (e.g. deploy this change in off-hours only).
 >
@@ -237,7 +243,8 @@
 
 **Breaking Changes**
 
-> Support for `alertingRules[].summary` was dropped in favor of `alertingRules[].description`. Although backwards-compatible this is silently breaking: Defined summaries will no longer be propagated.
+> Support for `alertingRules[].summary` was dropped in favor of `alertingRules[].description`. Although backwards-compatible this is silently breaking: Defined
+> summaries will no longer be propagated.
 
 ## 1.1.0
 

--- a/charts/spring-service/Chart.yaml
+++ b/charts/spring-service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: spring-service
 description: A generalized deployment for Meisterplan Spring Boot services in Kubernetes.
-version: 4.2.0
+version: 4.2.1

--- a/charts/spring-service/templates/post-deployment/prometheus-rules.yaml
+++ b/charts/spring-service/templates/post-deployment/prometheus-rules.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.alertingRules }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -9,6 +8,7 @@ metadata:
   name: "{{ .Values.serviceName }}"
 spec:
   groups:
+{{- if .Values.alertingRules }}
     - name: "{{ .Values.serviceName }}"
       rules:
         {{- range .Values.alertingRules }}

--- a/tests/spring-service/complex-service/expected/spring-service/templates/post-deployment/prometheus-rules.yaml
+++ b/tests/spring-service/complex-service/expected/spring-service/templates/post-deployment/prometheus-rules.yaml
@@ -1,0 +1,12 @@
+---
+# Source: spring-service/templates/post-deployment/prometheus-rules.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: "team-supercool"
+  labels:
+    app: kube-prometheus-stack
+    release: prometheus
+  name: "myservice"
+spec:
+  groups:


### PR DESCRIPTION
Before this fix, removed alerting rules were never really removed from k8s. With this fix, defining no alertingRules will still deploy an empty PromethuesRule, deleting effectively all previous rules as intended.

KNUTH-116070