### PR TITLE
Drop empty Prometheus rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # meisterplan-service
 
+## 3.2.1
+
+- No longer output PrometheusRules if no alerts are defined (will not validate otherwise)
+
 ## 3.2.0
 
 - Add `route.public.extraCspDomains` to allow appending additional domains to the enforced `Content-Security-Policy` `frame-ancestors` directive

--- a/charts/meisterplan-service/templates/post-deployment/prometheus-rules.yaml
+++ b/charts/meisterplan-service/templates/post-deployment/prometheus-rules.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.prometheus.alertingRules }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -5,7 +6,6 @@ metadata:
   name: "{{ .Release.Name }}"
 spec:
   groups:
-{{- if .Values.prometheus.alertingRules }}
     - name: "{{ .Release.Name }}"
       rules:
         {{- range .Values.prometheus.alertingRules }}

--- a/tests/meisterplan-service/complex-spring-service/expected/meisterplan-service/templates/post-deployment/prometheus-rules.yaml
+++ b/tests/meisterplan-service/complex-spring-service/expected/meisterplan-service/templates/post-deployment/prometheus-rules.yaml
@@ -1,9 +1,0 @@
----
-# Source: meisterplan-service/templates/post-deployment/prometheus-rules.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  namespace: "team-supercool"
-  name: "myservice"
-spec:
-  groups:

--- a/tests/meisterplan-service/simple-nginx-service/expected/meisterplan-service/templates/post-deployment/prometheus-rules.yaml
+++ b/tests/meisterplan-service/simple-nginx-service/expected/meisterplan-service/templates/post-deployment/prometheus-rules.yaml
@@ -1,9 +1,0 @@
----
-# Source: meisterplan-service/templates/post-deployment/prometheus-rules.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  namespace: "team-supercool"
-  name: "myservice"
-spec:
-  groups:

--- a/tests/meisterplan-service/simple-nodejs-service/expected/meisterplan-service/templates/post-deployment/prometheus-rules.yaml
+++ b/tests/meisterplan-service/simple-nodejs-service/expected/meisterplan-service/templates/post-deployment/prometheus-rules.yaml
@@ -1,9 +1,0 @@
----
-# Source: meisterplan-service/templates/post-deployment/prometheus-rules.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  namespace: "team-supercool"
-  name: "myservice"
-spec:
-  groups:

--- a/tests/meisterplan-service/simple-python-service/expected/meisterplan-service/templates/post-deployment/prometheus-rules.yaml
+++ b/tests/meisterplan-service/simple-python-service/expected/meisterplan-service/templates/post-deployment/prometheus-rules.yaml
@@ -1,9 +1,0 @@
----
-# Source: meisterplan-service/templates/post-deployment/prometheus-rules.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  namespace: "team-supercool"
-  name: "myservice"
-spec:
-  groups:


### PR DESCRIPTION
- validation does not pass anymore with k8s 1.35, empty prometheus rules cannot be applied

KNUTH-138692